### PR TITLE
grammar: added support for indented heredoc strings

### DIFF
--- a/grammars/terraform.cson
+++ b/grammars/terraform.cson
@@ -62,6 +62,7 @@ repository:
     ]
   heredocs:
     patterns: [
+      # standard heredoc strings
       {
         begin: '<<(\\w*JSON)$'
         beginCaptures:
@@ -124,6 +125,78 @@ repository:
           1:
             name: 'keyword.control.heredoc-token'
         end: '^(\\1)$'
+        endCaptures:
+          1:
+            name: 'keyword.control.heredoc-token'
+        name: 'keyword.operator.heredoc'
+        contentName: 'string.interpolated'
+      }
+
+      # indented heredoc strings
+      # these look very simliar to normal heredoc strings but require a minus
+      # in the start token and allow indentation on the end token
+      {
+        begin: '<<-(\\w*JSON)$'
+        beginCaptures:
+          1:
+            name: 'keyword.control.heredoc-token'
+        end: '^\\s+(\\1)$'
+        endCaptures:
+          1:
+            name: 'keyword.control.heredoc-token'
+        contentName: 'string.interpolated'
+        patterns: [
+          {include: 'source.json'}
+        ]
+      }
+      {
+        begin: '<<-(\\w*YA?ML)$'
+        beginCaptures:
+          1:
+            name: 'keyword.control.heredoc-token'
+        end: '^\\s+(\\1)$'
+        endCaptures:
+          1:
+            name: 'keyword.control.heredoc-token'
+        contentName: 'string.interpolated'
+        patterns: [
+          {include: 'source.yaml'}
+        ]
+      }
+      {
+        begin: '<<-(\\w*XML)$'
+        beginCaptures:
+          1:
+            name: 'keyword.control.heredoc-token'
+        end: '^\\s+(\\1)$'
+        endCaptures:
+          1:
+            name: 'keyword.control.heredoc-token'
+        contentName: 'string.interpolated'
+        patterns: [
+          {include: 'source.xml'}
+        ]
+      }
+      {
+        begin: '<<-(\\w*SH)$'
+        beginCaptures:
+          1:
+            name: 'keyword.control.heredoc-token'
+        end: '^\\s+(\\1)$'
+        endCaptures:
+          1:
+            name: 'keyword.control.heredoc-token'
+        contentName: 'string.interpolated'
+        patterns: [
+          {include: 'source.shell'}
+        ]
+      }
+      {
+        begin: '<<-(\\w+)$'
+        beginCaptures:
+          1:
+            name: 'keyword.control.heredoc-token'
+        end: '^\\s+(\\1)$'
         endCaptures:
           1:
             name: 'keyword.control.heredoc-token'


### PR DESCRIPTION
Thank you for forking this package. This PR adds the necessary grammar for [indented heredoc strings](https://www.terraform.io/docs/configuration/expressions.html#string-literals).

<img width="554" alt="image" src="https://user-images.githubusercontent.com/1217859/77735216-74378180-700a-11ea-9e36-669f978ecbfe.png">
